### PR TITLE
Replaced default test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,8 +2,18 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders introduction at start', () => {
   const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
+  const linkElement = getByText(/Introduction/i);
   expect(linkElement).toBeInTheDocument();
+  expect(linkElement.tagName).toMatch(/a/i);
+  expect(linkElement).toHaveClass('active');
+});
+
+test('renders measurement instruction nav element, but not active at start', () => {
+  const { getByText } = render(<App />);
+  const linkElement = getByText(/Measurement instructions/i);
+  expect(linkElement).toBeInTheDocument();
+  expect(linkElement.tagName).toMatch(/a/i);
+  expect(linkElement).not.toHaveClass('active');
 });


### PR DESCRIPTION
Replaced the default App test (which was failing) with two tests that test the nav bar status. Each test check for the presence of a navigation tab in app rendering, the "Introduction" and the "Measurement instructions". The first is checked to be active, while the second is checked to not be active.

Tests now pass.