### PR TITLE
Add fancy(er) math

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7975,6 +7975,11 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-fs-cache": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.3.tgz",
@@ -10794,6 +10799,14 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-mathjax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-mathjax/-/react-mathjax-1.0.1.tgz",
+      "integrity": "sha512-+mjFcciZY3GQoqiQm3aRTyDjgBKuoaXpY+SCONX00jScuPpTKwnASeFMS5+pbTIzDf5zPT2Y9ZZfQ9U/d4CKtQ==",
+      "requires": {
+        "load-script": "^1.0.0"
+      }
     },
     "react-overlays": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",
+    "react-mathjax": "^1.0.1",
     "react-scripts": "3.4.1",
     "svg-file-downloader": "0.0.2"
   },

--- a/src/TheMath.js
+++ b/src/TheMath.js
@@ -1,13 +1,14 @@
 import React from 'react';
 
 import Image from 'react-bootstrap/Image'
+import MathJax from 'react-mathjax'
 import theMath from './theMath.svg';
 
 
 export class TheMath extends React.Component {
     render() {
         return (
-            <>
+            <MathJax.Provider>
                 <p>I made a few starting assumptions:</p>
                 <ul>
                     <li>The angle from the top of the ear to the point of the nose is five degrees up.</li>
@@ -28,25 +29,29 @@ export class TheMath extends React.Component {
                     <li>Point B is the bridge of the nose. We know AB, AC, and BC, so we can find the angle θ1:</li>
                     <ul>
                         <li>
-                            The law of cosines says c*c = a*a + b*b − 2 * a * b * cos(C)
+                            The law of cosines says <MathJax.Node inline formula={'c^2 = a^2 + b^2 − 2ab\\, cos(C)'}/>
                         </li>
                         <li>
-                            θ1 = arccos((b*b + c*c - a*a) / (2 * b * c))
+                            <MathJax.Node inline formula={'θ1 = arccos((b^2 + c^2 - a^2) / 2bc)'}/>
                         </li>
                         <li>
-                            In this case, a = BC, b = AB, and c = AC
+                            In this case,<MathJax.Node inline formula={'a = BC'}/>, <MathJax.Node inline formula={'b = AB'}/>, and <MathJax.Node inline formula={'c = AC'}/>
                         </li>
                     </ul>
                     <li>I assumed a five degree angle up from the top of the ear to the nose. We know the distance from A to C, so:</li>
                     <ul>
-                        <li>Cx = cos(5) * AC</li>
-                        <li>Cy = sin(5) * AC</li>
+                        <li>
+                          <MathJax.Node inline formula={'Cx = cos(5^\\circ) \\cdot AC'}/>
+                        </li>
+                        <li>
+                          <MathJax.Node inline formula={'Cy = sin(5^\\circ) \\cdot AC'}/>
+                        </li>
                     </ul>
 
                     <li>The rest of the coordinates can be found by similar applications of the law of cosines and SOHCAHTOA, and are left as an exercise for the reader.</li>
-                    
+
                 </ul>Found a bug in my math? Think my math checks out but my assumptions are wrong? File an issue or make a pull request against <a href="https://github.com/fenichel/mask-pattern-generator/issues">my GitHub repo</a>.
-            </>
+            </MathJax.Provider>
         );
     }
 }


### PR DESCRIPTION
Closes #1 

Adds latex-looking math using MathJax via the [react-mathjax ](https://www.npmjs.com/package/react-mathjax)package.

I decided to make all of the var * var text into var^2 text. I also moved to dots instead of astrices. And some other formatting thingamawigglers. I wasn't sure exactly what you wanted, so I tried to keep the changes minimal but match traditional styling.

Here is what it looks like now:
![StyledMath](https://user-images.githubusercontent.com/25440652/87237581-f7f45e80-c3ac-11ea-9c0d-ebf4dba18415.png)

Here is what it looked like before:
![PreviousMath](https://user-images.githubusercontent.com/25440652/87237592-1fe3c200-c3ad-11ea-9009-3ceb97996de9.png)


As usual I'm happy to make any changes :D